### PR TITLE
update structure, move deps outside, add some objects description

### DIFF
--- a/Navidux/Sources/Navidux/Coordinator.swift
+++ b/Navidux/Sources/Navidux/Coordinator.swift
@@ -3,8 +3,6 @@ import UIKit
 /// Main Object that used in navigation. Have many different types of presentation and inner methods to manipulate navigation stack.
 /// Work on states with associated values.
 /// - Note use **actionReducer(action:)** function with some action to change state of navigation stack. It's trigger inner function to change navigation screen.
-/// - Note use **start()** function to trigger first default screen or **actionReducer(action:)** with **restruct** action to set up inital navigation stack state.
 public protocol Coordinator: AnyObject {
     func actionReducer(action: Navigation.Action)
-    func start()
 }

--- a/Navidux/Sources/Navidux/NaviduxScreen.swift
+++ b/Navidux/Sources/Navidux/NaviduxScreen.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// NaviduxScreen its alternative to simple Enumeration with possibility to extension.
+/// if you want to add case with new screen you have to:
+/// ``` swift
+/// extension NaviduxScreen {
+///     static let newScreen = NaviduxScreen(
+///         description: "someDescription",
+///         screenClass: YourScreenTypeInheritedFromUIViewController.self
+///     )
+/// }
+/// ```
+/// - Note: You can place extension in another module.
+public class NaviduxScreen: ExtendableEnum {
+    public var asScreenClass: UIViewController.Type
+    
+    public init(screenClass: UIViewController.Type) {
+        self.asScreenClass = screenClass
+    }
+}

--- a/Navidux/Sources/Navidux/Navigation.swift
+++ b/Navidux/Sources/Navidux/Navigation.swift
@@ -2,27 +2,19 @@ import UIKit
 import SwiftUI
 
 public enum Navigation: Equatable {
-    public enum Screen: Equatable {
-        case firstScreen
-        case secondScreen
-        
-        var asScreenClass: UIViewController.Type {
-            switch self {
-            case .firstScreen:
-                return UIViewController.self
-            case .secondScreen:
-                return UIViewController.self
-            }
-        }
-    }
-    
+    /// PresentationStyle uses to choose correct form of pushing your screen.
+    /// - Note:
+    /// + fullscren - its normal presentation like `UINavigationController.push(...)` without additional settings.
+    /// + model - its modal presentation like `UINavigationController.present(...)` without additional settings.
+    /// + bottomSheet - its modal presentation of the screen from bottom part with simple animation.
+    /// + custom - its fully customisable animation for `UINavigationController.push(...)` with your own parameters. *WORK IN PROGRESS*
     public enum PresentationStyle {
         case fullscreen
         case modal
         case bottomSheet([BottomSheetSize])
         case custom(UIViewControllerTransitioningDelegate)
     }
-    
+
     public enum BottomSheetSize {
         case fixed(CGFloat)
         case halfScreen
@@ -30,11 +22,10 @@ public enum Navigation: Equatable {
     }
 
     public enum Action {
-        case start(ScreenConfig)
-        case push(Screen, ScreenConfig, PresentationStyle)
+        case push(NaviduxScreen, ScreenConfig, PresentationStyle)
         case pop(NullablePayload)
-        case popUntil(Screen, NullablePayload)
-        case restruct([(Screen, ScreenConfig)])
+        case popUntil(NaviduxScreen, NullablePayload)
+        case restruct([(NaviduxScreen, ScreenConfig)])
         case showAlert(AlertConfiguration)
     }
 }

--- a/Navidux/Sources/Navidux/NavigationCoordinator.swift
+++ b/Navidux/Sources/Navidux/NavigationCoordinator.swift
@@ -12,8 +12,4 @@ public final class NavigationCoordinator: Coordinator {
         self.screenAssembler = screenAssembler
         self.state = state
     }
-
-    public func start() {
-        actionReducer(action: .start(ScreenConfig(navigationTitle: "Start Screen", isNeedSetBackButton: false)))
-    }
 }

--- a/Navidux/Sources/Navidux/NavigationCoordinatorProxy.swift
+++ b/Navidux/Sources/Navidux/NavigationCoordinatorProxy.swift
@@ -1,3 +1,24 @@
+///Proxy give possibility to create `ScreenAssembler` that nessasary for `NavigationCoordinator`.
+///Usage: after declaration `NavigationCoordinatorProxy` you can create `ScreenAssembler`.
+///Next step to create real `Coordinator`. And last stage is set subject property as real `Coordinator`.
+/// - Example:
+///``` swift
+///let navigationController = NavigationControllerImpl()
+///let screenFactory = NaviduxScreenFactory()
+///let alertFactory = AlertFactoryImpl()
+///let navigationCoordinatorProxy = NavigationCoordinatorProxy()
+///let screenAssembler = NaviduxScreenAssembler(
+///    screenFactory: screenFactory,
+///    alertFactory: alertFactory,
+///    screenCoordinator: navigationCoordinatorProxy
+///)
+///
+///let navigationCoordinator = NavigationCoordinator(
+///    navigationController,
+///    screenAssembler: screenAssembler
+///)
+///navigationCoordinatorProxy.subject = navigationCoordinator
+///```
 public final class NavigationCoordinatorProxy: Coordinator {
     public var subject: Coordinator!
 
@@ -7,9 +28,5 @@ public final class NavigationCoordinatorProxy: Coordinator {
 
     public func actionReducer(action: Navigation.Action) {
         subject.actionReducer(action: action)
-    }
-
-    public func start() {
-        subject.start()
     }
 }

--- a/Navidux/Sources/Navidux/ScreenAssembler.swift
+++ b/Navidux/Sources/Navidux/ScreenAssembler.swift
@@ -1,4 +1,4 @@
 public protocol ScreenAssembler {
-    func assemblyScreen(screenType: Navigation.Screen, config: ScreenConfig) -> any NavigationScreen
+    func assemblyScreen(screenType: NaviduxScreen, config: ScreenConfig) -> any NavigationScreen
     func assemblyAlert(configuration: AlertConfiguration) -> AlertScreen
 }

--- a/Navidux/Sources/Navidux/ScreenFactory.swift
+++ b/Navidux/Sources/Navidux/ScreenFactory.swift
@@ -1,1 +1,15 @@
+/// ScreenFactory uses as part of `ScreenAssembly` module and helps you to create `NavigationScreen` in `assmblyScreen` function.
+/// You can extend protocol with `(Dependencies) -> (Coordinator, Configuration) -> Resulted VC` function and call them in assembler
+/// on call.
+/// - Example:
+/// ``` swift
+/// import Navidux
+///
+/// extension Navidux.ScreenFactory {
+///    public var someScreenFactory: (Coordinator?, ScreenConfig) -> any NavigationScreen {
+///         { coordinator, config
+///             return MyViewControllerConformedNavigationScreen()
+///         }
+///    }
+/// ```
 public protocol ScreenFactory {}

--- a/Navidux/Sources/Navidux/alert/AlertFactory.swift
+++ b/Navidux/Sources/Navidux/alert/AlertFactory.swift
@@ -1,9 +1,13 @@
 import UIKit
 
-public final class AlertFactory {
-    func createAlert(configuration : AlertConfiguration) -> AlertScreen {
+public protocol AlertFactory {
+    func createAlert(configuration : AlertConfiguration) -> AlertScreen
+}
+
+public final class AlertFactoryImpl: AlertFactory {
+    public func createAlert(configuration : AlertConfiguration) -> AlertScreen {
         AlertScreen(configuration: configuration)
     }
-    
+
     public init() {}
 }

--- a/Navidux/Sources/Navidux/alert/AlertScreen.swift
+++ b/Navidux/Sources/Navidux/alert/AlertScreen.swift
@@ -2,11 +2,11 @@ import UIKit
 
 public final class AlertScreen {
     let configuration: AlertConfiguration
-    
-    init(configuration: AlertConfiguration) {
+
+    public init(configuration: AlertConfiguration) {
         self.configuration = configuration
     }
-    
+
     func generateAlert(dismissedCallback: @escaping () -> Void) -> UIAlertController {
         let alert = UIAlertController(
             title: configuration.title,

--- a/Navidux/Sources/Navidux/extensions/ExtendableEnum.swift
+++ b/Navidux/Sources/Navidux/extensions/ExtendableEnum.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public protocol ExtendableEnum: AnyObject, Hashable { }
+
+extension ExtendableEnum {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+      }
+}
+
+public func ==<T: ExtendableEnum>(lhs: T, rhs: T) -> Bool {
+    return lhs === rhs
+}

--- a/Navidux/Sources/Navidux/implemention/NavigationReducer.swift
+++ b/Navidux/Sources/Navidux/implemention/NavigationReducer.swift
@@ -1,13 +1,6 @@
 extension NavigationCoordinator {
     public func actionReducer(action: Navigation.Action) {
         switch action {
-        case let .start(config):
-            let controller = screenAssembler.assemblyScreen(
-                screenType: .firstScreen,
-                config: config
-            )
-            pushNew(screen: controller, style: .fullscreen, animated: false)
-            
         case let .push(screen, config, presentationStyle):
             var controller: any NavigationScreen
             controller = screenAssembler.assemblyScreen(screenType: screen, config: config)
@@ -41,7 +34,7 @@ extension NavigationCoordinator {
     }
     
     private func findCertain(
-        controller: Navigation.Screen,
+        controller: NaviduxScreen,
         in stack: [any NavigationScreen]
     ) -> (any NavigationScreen)? {
         return stack.last(where: { [controller] in

--- a/Navidux/Sources/Navidux/implemention/Payload.swift
+++ b/Navidux/Sources/Navidux/implemention/Payload.swift
@@ -1,5 +1,17 @@
 public typealias NullablePayload = (any Payload)?
 
-public protocol Payload: Equatable {}
+/// Payload uses to transfer some data from screen to screen.
+/// In default implementation on push new screen `Payload` added to `ScreenConfig` objet.
+/// You have access to data in `ScreenAssemble` object.
+/// Another case with access, you have on `.pop` and `.popUntil` actions.
+/// This payload return as parameter in default implementation of `gotUpdatedData(_:)` in `NavigayionScreen` protocol.
+/// If you want access data at this access point you have to override `gotUpdatedData(_:)` function in your inherited ViewController.
+public protocol Payload: Hashable {
+    associatedtype T: Hashable
+    var data: T { get }
+}
 
-public struct VoidPayload: Payload {}
+/// It's shortcut for Payload.
+public struct VoidPayload: Payload {
+    public var data = false
+}

--- a/Navidux/Sources/Navidux/screens/ScreenConfig.swift
+++ b/Navidux/Sources/Navidux/screens/ScreenConfig.swift
@@ -1,9 +1,25 @@
 public struct ScreenConfig: Equatable {
     let navigationTitle: String
     var isNeedSetBackButton: Bool
-    
-    public init(navigationTitle: String, isNeedSetBackButton: Bool = true) {
+    public var initialPayload: NullablePayload
+
+    /// - Parameters:
+    ///     - navigationTitle: Set navigation title for screen on init.
+    ///     - isNeedSetBackButton: Set or remove back button in navigation bar. Action on callback can be overrided in `NavigationScreen` with function `onBackCallback`.
+    ///     - initialPayload: Uses as additional parameter with some data to initialise `NavigationScreen` or some Module/Fabric.
+    public init(
+        navigationTitle: String,
+        isNeedSetBackButton: Bool = true,
+        initialPayload: NullablePayload = nil
+    ) {
         self.navigationTitle = navigationTitle
         self.isNeedSetBackButton = isNeedSetBackButton
+        self.initialPayload = initialPayload
+    }
+
+    public static func == (lhs: ScreenConfig, rhs: ScreenConfig) -> Bool {
+        lhs.navigationTitle == rhs.navigationTitle
+        && lhs.isNeedSetBackButton == rhs.isNeedSetBackButton
+        && lhs.initialPayload?.data.hashValue == rhs.initialPayload?.data.hashValue
     }
 }

--- a/Navidux/Tests/NaviduxTests/Fixtures/NaviduxScreenFixture.swift
+++ b/Navidux/Tests/NaviduxTests/Fixtures/NaviduxScreenFixture.swift
@@ -1,0 +1,19 @@
+@testable import Navidux
+
+extension NaviduxScreen {
+    public static let firstScreen = NaviduxScreen(
+        screenClass: FirstController.self
+    )
+    public static let secondScreen = NaviduxScreen(
+        screenClass: SecondController.self
+    )
+    public static let thirdScreen = NaviduxScreen(
+        screenClass: ThirdController.self
+    )
+}
+
+final class FirstController: ViewController {}
+
+final class SecondController: ViewController {}
+
+final class ThirdController: ViewController {}

--- a/Navidux/Tests/NaviduxTests/Fixtures/ScreenAssemblerStub.swift
+++ b/Navidux/Tests/NaviduxTests/Fixtures/ScreenAssemblerStub.swift
@@ -1,7 +1,7 @@
 @testable import Navidux
 
 enum ScreenAssemblerStubAction: Equatable {
-    case assembleScreen(Navidux.Navigation.Screen)
+    case assembleScreen(Navidux.NaviduxScreen)
     case assembleAlert(Navidux.AlertConfiguration)
 }
 
@@ -18,7 +18,7 @@ final class ScreenAssemblerStub: ScreenAssembler {
     }
 
     func assemblyScreen(
-        screenType: Navidux.Navigation.Screen,
+        screenType: Navidux.NaviduxScreen,
         config: Navidux.ScreenConfig
     ) -> any Navidux.NavigationScreen {
         screenToPush ?? NaviduxFixture.mockNavigationScreen(coordinator: navigation, tag: vcTag ?? "")

--- a/Navidux/Tests/NaviduxTests/NavigationCoordinatorTests.swift
+++ b/Navidux/Tests/NaviduxTests/NavigationCoordinatorTests.swift
@@ -13,21 +13,7 @@ final class NavigationCoordinatorTests: XCTestCase {
         navigationController,
         screenAssembler: screenAssembler
     )
-    
-    func test_start_pushDefaultScreen() {
-        screenAssembler.navigation = navigationCoordinator
 
-        navigationCoordinator.start()
-        
-        XCTAssertEqual(
-            navigationController.callingStack,
-            [
-                .pushViewController(tag: NaviduxFixture.oneScreenTag),
-                .addToStack(tag: NaviduxFixture.oneScreenTag)
-            ]
-        )
-    }
-    
     func test_pushFullscreen_addCallForPush() {
         screenAssembler.navigation = navigationCoordinator
 


### PR DESCRIPTION
Remove `Navigation.Screen` enum and use extendable analog of enum. It's give an opportunity to add screen without change source code of library.
Remove `start()` method for the useless.
Add Payload to `ScreenConfig` as `initialPayload`.
Add Fixture for tests.
Add documentation for some of objects.